### PR TITLE
Optimize for size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.bin
 *.img
+*.lst
+*.lst.*

--- a/dino.asm
+++ b/dino.asm
@@ -99,14 +99,14 @@ _game_loop:
         mov cx, max_enemies
         mov di, enemies_start
     _dhe_l:
-        mov bl, byte [di]       ; get x coord
+        mov bx, word [di]       ; get x,y coord
         or bl, bl               ; checking if the enemy is outside the screen
         jz _dhe_re              ; if so, try creating a new one
 
         ; setting vars for draw_sprite
         mov dl, enemy_scaling   ; scaling
         mov si, [di+2]          ; get sprite address
-        mov al, [di+1]          ; y position
+        mov al, bh              ; y position
         call draw_sprite
 
         sub byte [di], dh       ; subtract from x position
@@ -139,9 +139,7 @@ _game_loop:
             mov byte @(enemy_timer_b), al       ; setting the enemy timer
 
             ; preparing enemy
-            mov byte [di], 255      ; set horizontal position
-            mov byte [di+1], 139    ; set vertical position
-
+            mov word [di], 255 | (139 << 8) ; set horizontal & vertical position
             mov word [di+2], cactus+7   ; setting sprite to cactus
 
             ; randomizing enemy
@@ -161,7 +159,9 @@ _game_loop:
         ; end random_enemy
 
     _dhe_i_end:
-        add di, enemy_size      ; advance by enemy_size
+        ; advance by enemy_size (di += 4)
+        scasw
+        scasw
         loop _dhe_l
     ; end handle_draw_enemies
 

--- a/dino.asm
+++ b/dino.asm
@@ -23,16 +23,19 @@ _start:
 
     xor ax, ax
     ; clearing variable memory
-    mov cx, VAR_END-VAR_BASE
-    mov di, bp
-    rep ds stosb
+    mov di, VAR_END-VAR_BASE-1
+    ; use a manual loop since the destination is in ds
+    .clear:
+        mov [bp+di], al
+        dec di
+        jns .clear
 
     ; initialize vars
     mov byte @(e_t_set_b), enemy_timer_max   ; enemy timer
 
     ; draw ground line
     mov di, ground_start
-    mov cl, screen_width/2 ; ch=0 from above
+    mov cx, screen_width/2
     ; ax=0 from above
     rep stosw
 

--- a/dino.asm
+++ b/dino.asm
@@ -99,7 +99,6 @@ _game_loop:
         mov cx, max_enemies
         mov di, enemies_start
     _dhe_l:
-        xor bx, bx
         mov bl, byte [di]       ; get x coord
         or bl, bl               ; checking if the enemy is outside the screen
         jz _dhe_re              ; if so, try creating a new one
@@ -107,7 +106,6 @@ _game_loop:
         ; setting vars for draw_sprite
         mov dl, enemy_scaling   ; scaling
         mov si, [di+2]          ; get sprite address
-        xor ax, ax
         mov al, [di+1]          ; y position
         call draw_sprite
 
@@ -152,7 +150,7 @@ _game_loop:
             shr al, 1
             jnc _re_end
 
-            add word [di+2], 8      ; changing sprite from cactus to bomber
+            add word [di+2], bomber-cactus  ; changing sprite from cactus to bomber
             sub byte [di+1], 18     ; changing bomber's vertical position
 
             shr al, 1
@@ -199,20 +197,18 @@ _game_loop:
         mov bx, dino_initial_x
 
         ; check if to subtract the jump value
-        xor cx, cx
         mov cl, @(rows_up_b)
         cmp cl, 0
         jng _dd_no_jump
-        sub ax, cx
+        sub al, cl
     _dd_no_jump:
 
         ; check for collisions
         push ax
         mov dx, screen_width
         mul dx
-        add ax, bx
-        mov di, ax
-        add di, 5*dino_scaling
+        lea di, [bx+5*dino_scaling]
+        add di, ax
         mov byte cl, [es:di]
 
         ; check for crouch
@@ -278,7 +274,7 @@ game_over:
     int 0x10
 
     mov ah, 0x0e            ; print char interrupt
-    mov cx, 10              ; 10 chars
+    mov cx, str_go_end-str_go  ; 10 chars
     mov si, str_go          ; point to game_over string
 
 _go_l:
@@ -302,15 +298,16 @@ _dd_black:
     ret
 
 
-; ax = y coord, bx = x coord, dl = scaling;
+; al = y coord, bl = x coord, dl = scaling;
 ; modify coords and scaling; scaling - 1 for 8x8 pixels;
 ; mov the address of the sprite's last byte to the si register (addr+7);
 draw_sprite:
     push cx
     push di
 
-    mov @(y_coord_w), ax
-    mov @(x_coord_w), bx
+    ; high bytes of the words will always be 0
+    mov byte @(y_coord_w), al
+    mov byte @(x_coord_w), bl
     mov bl, 8               ; bl will act as the sprite's byte counter
     mov bh, dl              ; bh will act as the row scaling counter
 
@@ -397,6 +394,7 @@ score_divisor   equ 10
 
 ; game_over string const
 str_go  db  "game over!"
+str_go_end:
 
 ; sprite data
 dino    db  0b00000110, \

--- a/makefile
+++ b/makefile
@@ -3,29 +3,29 @@ ifndef VERBOSE
 .SILENT:
 endif
 
-main: dino.asm
-	nasm -f bin -o a.bin dino.asm
+a.bin: dino.asm
+	nasm -f bin -l dino.lst -o $@ $<
+	cut -b17- dino.lst > dino.lst.new
+	-[ -f dino.lst.old ] && diff -U1 dino.lst.old dino.lst.new
+	cp dino.lst.new dino.lst.old
 
-run: dino.asm
-	make
+.PHONY: run count monitor floppy clean
+
+run: a.bin
 	qemu-system-x86_64 -drive file=a.bin,format=raw,index=0,media=disk || \
 	qemu-system-i386 -drive file=a.bin,format=raw,index=0,media=disk
-	rm ./a.bin
 
-count: dino.asm
-	make
+count: a.bin
 	echo -n "SIZE: "; stat -c%s ./a.bin
-	rm ./a.bin
 
-monitor: dino.asm
-	make
+monitor: a.bin
 	qemu-system-x86_64 -monitor stdio \
 		-drive file=a.bin,format=raw,index=0,media=disk
 	echo
-	rm ./a.bin
 
-floppy: dino.asm
-	make
+floppy: a.bin
 	dd if=/dev/zero of=floppy.img count=1440 bs=1KiB
 	dd if=./a.bin of=floppy.img conv=notrunc
-	rm ./a.bin
+
+clean:
+	rm -f a.bin dino.lst


### PR DESCRIPTION
Main changes:
* Switch to using `bp` as the pointer to the variable area instead of using absolute memory references (saves 1 byte per modr/m).
* Use `es` segment override for `lodsb` to "reverse" the segments (instead of using manual `loop`s).
* Clear the variable area in one pass.

More changes:
* Use bytes instead of words for sprite positions
* Use `lea` instead of 2x `add`.
* Load two byte registers using a single word operation.
* Use `scasw` to increment `di`.
* Re-use existing register values (mostly instead of a 0 immediate to `cmp`).
* Re-use code bytes as an "immediate" operand to `div`.

Currently 39 free bytes left over.

Fixes #3.